### PR TITLE
Modify firefoxpatch.c to also deal with Thunderbird/BB JumpList crashes

### DIFF
--- a/01-Extended DLLs/KxCom/firefoxpatch.c
+++ b/01-Extended DLLs/KxCom/firefoxpatch.c
@@ -11,7 +11,7 @@ HRESULT WINAPI Ext_CoCreateInstance(
 	OUT	LPVOID		*ppv)
 {
 	unless (KexData->IfeoParameters.DisableAppSpecific){
-		if (AshExeBaseNameIs(L"firefox.exe")) {
+		if (AshExeBaseNameIs(L"firefox.exe") || AshExeBaseNameIs(L"thunderbird.exe") || AshExeBaseNameIs(L"betterbird.exe")) {
 			if ((IsEqualCLSID(rclsid, &CLSID_DestinationList) && pUnkOuter == NULL && dwClsContext == CLSCTX_INPROC_SERVER && IsEqualIID(riid, &IID_ICustomDestinationList)) || (pUnkOuter == NULL && dwClsContext == CLSCTX_INPROC_SERVER && IsEqualIID(riid, &IID_IObjectCollection))) return E_NOTIMPL;
 		}
 	}


### PR DESCRIPTION
This simple fix/extension of the original Firefox patch enables Thunderbird/Betterbird 128esr to run without modifications under VxKex-NEXT