### PR TITLE
kxbase IsProcessCritical

### DIFF
--- a/00-Common Headers/KxBase.h
+++ b/00-Common Headers/KxBase.h
@@ -699,6 +699,10 @@ KXBASEAPI BOOL WINAPI GetProcessMitigationPolicy(
 	OUT	PVOID						Buffer,
 	IN	SIZE_T						BufferCb);
 
+KXBASEAPI BOOL WINAPI IsProcessCritical(
+    IN  HANDLE  ProcessHandle,
+    OUT PBOOL   Critical);
+
 //
 // file.c
 //

--- a/01-Extended DLLs/KxBase/kxbase.def
+++ b/01-Extended DLLs/KxBase/kxbase.def
@@ -29,6 +29,7 @@ EXPORTS
 	GetProcessDefaultCpuSetMasks
 	SetProcessMitigationPolicy
 	GetProcessMitigationPolicy
+	IsProcessCritical
 
 	;; pssapi.c
 	PssCaptureSnapshot

--- a/01-Extended DLLs/KxBase/process.c
+++ b/01-Extended DLLs/KxBase/process.c
@@ -217,6 +217,19 @@ KXBASEAPI BOOL WINAPI GetProcessMitigationPolicy(
 	return FALSE;
 }
 
+KXBASEAPI BOOL WINAPI IsProcessCritical(
+    IN  HANDLE  ProcessHandle,
+    OUT PBOOL   Critical)
+{
+    ULONG breakOnTermination = 0;
+    NTSTATUS status = NtQueryInformationProcess(ProcessHandle, (PROCESSINFOCLASS)29,  &breakOnTermination, sizeof(breakOnTermination), NULL);
+    if (NT_SUCCESS(status)) {
+        *Critical = (breakOnTermination != 0);
+        return TRUE;
+    }
+    return FALSE;
+}
+
 KXBASEAPI BOOL WINAPI Ext_IsProcessInJob(
 	IN	HANDLE	ProcessHandle,
 	IN	HANDLE	JobHandle,


### PR DESCRIPTION
e.g. needed to start mitmproxy (mitmweb.exe, mitmdump.exe) for whatever reason