### PR TITLE
Fix classic Bluetooth API forwarding (#435)

### DIFF
--- a/01-Extended DLLs/KxUser/kxuser.def
+++ b/01-Extended DLLs/KxUser/kxuser.def
@@ -25,28 +25,28 @@ EXPORTS
 	;;BluetoothEnumerateInstalledServicesEx
 	;;BluetoothFindBrowseGroupClose
 	;;BluetoothFindClassIdClose
-	;;BluetoothFindDeviceClose
+	BluetoothFindDeviceClose = bthprops.cpl.BluetoothFindDeviceClose
 	;;BluetoothFindFirstBrowseGroup
 	;;BluetoothFindFirstClassId
-	;;BluetoothFindFirstDevice
+	BluetoothFindFirstDevice = bthprops.cpl.BluetoothFindFirstDevice
 	;;BluetoothFindFirstProfileDescriptor
 	;;BluetoothFindFirstProtocolDescriptorStack
 	;;BluetoothFindFirstProtocolEntry
-	;;BluetoothFindFirstRadio
+	BluetoothFindFirstRadio = bthprops.cpl.BluetoothFindFirstRadio
 	;;BluetoothFindFirstService
 	;;BluetoothFindFirstServiceEx
 	;;BluetoothFindNextBrowseGroup
 	;;BluetoothFindNextClassId
-	;;BluetoothFindNextDevice
+	BluetoothFindNextDevice = bthprops.cpl.BluetoothFindNextDevice
 	;;BluetoothFindNextProfileDescriptor
 	;;BluetoothFindNextProtocolDescriptorStack
 	;;BluetoothFindNextProtocolEntry
-	;;BluetoothFindNextRadio
+	BluetoothFindNextRadio = bthprops.cpl.BluetoothFindNextRadio
 	;;BluetoothFindNextService
 	;;BluetoothFindProfileDescriptorClose
 	;;BluetoothFindProtocolDescriptorStackClose
 	;;BluetoothFindProtocolEntryClose
-	;;BluetoothFindRadioClose
+	BluetoothFindRadioClose = bthprops.cpl.BluetoothFindRadioClose
 	;;BluetoothFindServiceClose
 	;;BluetoothGetDeviceInfo
 	;;BluetoothGetRadioInfo


### PR DESCRIPTION
Fixes #435

Forward classic Bluetooth enumeration APIs from KxUser
to the Windows 7 implementation in bthprops.cpl.

This avoids ERROR_PROC_NOT_FOUND when BluetoothApis.dll
is redirected to KxUser by VxKex-NEXT.