### PR TITLE
Fix classic Bluetooth API compatibility (#435)

### DIFF
--- a/01-Extended DLLs/KxUser/blutooth.c
+++ b/01-Extended DLLs/KxUser/blutooth.c
@@ -49,11 +49,11 @@ GetBthPropsModule(
 
 KXUSERAPI HBLUETOOTH_DEVICE_FIND WINAPI
 BluetoothFindFirstDevice(
-    const BLUETOOTH_DEVICE_SEARCH_PARAMS *pbtsp,
+    BLUETOOTH_DEVICE_SEARCH_PARAMS *pbtsp,
     BLUETOOTH_DEVICE_INFO *pbtdi)
 {
     typedef HBLUETOOTH_DEVICE_FIND (WINAPI *PFN_BluetoothFindFirstDevice)(
-        const BLUETOOTH_DEVICE_SEARCH_PARAMS *,
+        BLUETOOTH_DEVICE_SEARCH_PARAMS *,
         BLUETOOTH_DEVICE_INFO *);
 
     HMODULE Module;
@@ -128,11 +128,11 @@ BluetoothFindDeviceClose(
 
 KXUSERAPI HBLUETOOTH_RADIO_FIND WINAPI
 BluetoothFindFirstRadio(
-    const BLUETOOTH_FIND_RADIO_PARAMS *pbtfrp,
+    BLUETOOTH_FIND_RADIO_PARAMS *pbtfrp,
     HANDLE *phRadio)
 {
     typedef HBLUETOOTH_RADIO_FIND (WINAPI *PFN_BluetoothFindFirstRadio)(
-        const BLUETOOTH_FIND_RADIO_PARAMS *,
+        BLUETOOTH_FIND_RADIO_PARAMS *,
         HANDLE *);
 
     HMODULE Module;

--- a/01-Extended DLLs/KxUser/blutooth.c
+++ b/01-Extended DLLs/KxUser/blutooth.c
@@ -1,10 +1,212 @@
 #include "buildcfg.h"
 #include "kxuserp.h"
-//#pragma comment(lib, "bthprops.lib")
+
+#include <BluetoothAPIs.h>
+
+//
+// Classic Bluetooth APIs are implemented by Windows in bthprops.cpl.
+//
+// Do not use a .def forwarder to bthprops.cpl. KxUser instead loads the
+// system copy explicitly and resolves the required entry points.
+//
+// LoadSystemLibrary() temporarily disables VxKex DLL rewriting while
+// loading bthprops.cpl and its dependencies.
+//
+
+static INIT_ONCE BthPropsInitOnce = INIT_ONCE_STATIC_INIT;
+static HMODULE BthPropsModule;
+
+static BOOL CALLBACK
+InitializeBthProps(
+    PINIT_ONCE InitOnce,
+    PVOID Parameter,
+    PVOID *Context)
+{
+    UNREFERENCED_PARAMETER(InitOnce);
+    UNREFERENCED_PARAMETER(Parameter);
+    UNREFERENCED_PARAMETER(Context);
+
+    BthPropsModule = LoadSystemLibrary(L"bthprops.cpl");
+
+    return BthPropsModule != NULL;
+}
+
+static HMODULE
+GetBthPropsModule(
+    VOID)
+{
+    if (!InitOnceExecuteOnce(
+        &BthPropsInitOnce,
+        InitializeBthProps,
+        NULL,
+        NULL))
+    {
+        return NULL;
+    }
+
+    return BthPropsModule;
+}
+
+KXUSERAPI HBLUETOOTH_DEVICE_FIND WINAPI
+BluetoothFindFirstDevice(
+    const BLUETOOTH_DEVICE_SEARCH_PARAMS *pbtsp,
+    BLUETOOTH_DEVICE_INFO *pbtdi)
+{
+    typedef HBLUETOOTH_DEVICE_FIND (WINAPI *PFN_BluetoothFindFirstDevice)(
+        const BLUETOOTH_DEVICE_SEARCH_PARAMS *,
+        BLUETOOTH_DEVICE_INFO *);
+
+    HMODULE Module;
+    PFN_BluetoothFindFirstDevice Function;
+
+    Module = GetBthPropsModule();
+
+    if (!Module)
+        return NULL;
+
+    Function = (PFN_BluetoothFindFirstDevice)GetProcAddress(
+        Module,
+        "BluetoothFindFirstDevice");
+
+    if (!Function)
+        return NULL;
+
+    return Function(pbtsp, pbtdi);
+}
+
+KXUSERAPI BOOL WINAPI
+BluetoothFindNextDevice(
+    HBLUETOOTH_DEVICE_FIND hFind,
+    BLUETOOTH_DEVICE_INFO *pbtdi)
+{
+    typedef BOOL (WINAPI *PFN_BluetoothFindNextDevice)(
+        HBLUETOOTH_DEVICE_FIND,
+        BLUETOOTH_DEVICE_INFO *);
+
+    HMODULE Module;
+    PFN_BluetoothFindNextDevice Function;
+
+    Module = GetBthPropsModule();
+
+    if (!Module)
+        return FALSE;
+
+    Function = (PFN_BluetoothFindNextDevice)GetProcAddress(
+        Module,
+        "BluetoothFindNextDevice");
+
+    if (!Function)
+        return FALSE;
+
+    return Function(hFind, pbtdi);
+}
+
+KXUSERAPI BOOL WINAPI
+BluetoothFindDeviceClose(
+    HBLUETOOTH_DEVICE_FIND hFind)
+{
+    typedef BOOL (WINAPI *PFN_BluetoothFindDeviceClose)(
+        HBLUETOOTH_DEVICE_FIND);
+
+    HMODULE Module;
+    PFN_BluetoothFindDeviceClose Function;
+
+    Module = GetBthPropsModule();
+
+    if (!Module)
+        return FALSE;
+
+    Function = (PFN_BluetoothFindDeviceClose)GetProcAddress(
+        Module,
+        "BluetoothFindDeviceClose");
+
+    if (!Function)
+        return FALSE;
+
+    return Function(hFind);
+}
+
+KXUSERAPI HBLUETOOTH_RADIO_FIND WINAPI
+BluetoothFindFirstRadio(
+    const BLUETOOTH_FIND_RADIO_PARAMS *pbtfrp,
+    HANDLE *phRadio)
+{
+    typedef HBLUETOOTH_RADIO_FIND (WINAPI *PFN_BluetoothFindFirstRadio)(
+        const BLUETOOTH_FIND_RADIO_PARAMS *,
+        HANDLE *);
+
+    HMODULE Module;
+    PFN_BluetoothFindFirstRadio Function;
+
+    Module = GetBthPropsModule();
+
+    if (!Module)
+        return NULL;
+
+    Function = (PFN_BluetoothFindFirstRadio)GetProcAddress(
+        Module,
+        "BluetoothFindFirstRadio");
+
+    if (!Function)
+        return NULL;
+
+    return Function(pbtfrp, phRadio);
+}
+
+KXUSERAPI BOOL WINAPI
+BluetoothFindNextRadio(
+    HBLUETOOTH_RADIO_FIND hFind,
+    HANDLE *phRadio)
+{
+    typedef BOOL (WINAPI *PFN_BluetoothFindNextRadio)(
+        HBLUETOOTH_RADIO_FIND,
+        HANDLE *);
+
+    HMODULE Module;
+    PFN_BluetoothFindNextRadio Function;
+
+    Module = GetBthPropsModule();
+
+    if (!Module)
+        return FALSE;
+
+    Function = (PFN_BluetoothFindNextRadio)GetProcAddress(
+        Module,
+        "BluetoothFindNextRadio");
+
+    if (!Function)
+        return FALSE;
+
+    return Function(hFind, phRadio);
+}
+
+KXUSERAPI BOOL WINAPI
+BluetoothFindRadioClose(
+    HBLUETOOTH_RADIO_FIND hFind)
+{
+    typedef BOOL (WINAPI *PFN_BluetoothFindRadioClose)(
+        HBLUETOOTH_RADIO_FIND);
+
+    HMODULE Module;
+    PFN_BluetoothFindRadioClose Function;
+
+    Module = GetBthPropsModule();
+
+    if (!Module)
+        return FALSE;
+
+    Function = (PFN_BluetoothFindRadioClose)GetProcAddress(
+        Module,
+        "BluetoothFindRadioClose");
+
+    if (!Function)
+        return FALSE;
+
+    return Function(hFind);
+}
 
 //
 // These are all stubs. No idea how to begin implementing them properly.
-// Let's see if they are even that important.
 //
 
 KXUSERAPI HRESULT WINAPI BluetoothGATTAbortReliableWrite(

--- a/01-Extended DLLs/KxUser/blutooth.c
+++ b/01-Extended DLLs/KxUser/blutooth.c
@@ -1,7 +1,23 @@
 #include "buildcfg.h"
 #include "kxuserp.h"
 
-#include <BluetoothAPIs.h>
+//
+// The Windows 7.1 SDK BluetoothAPIs.h contains malformed
+// "#pragma deprecate" directives which produce C4068 warnings.
+// KxUser is built with /WX, so do not include that header here.
+//
+// The six classic APIs below only need opaque structure pointers and
+// HANDLE-based enumeration types, so forward-declare the types locally.
+// This also avoids introducing conflicting declarations from the
+// Windows 7.1 SDK Bluetooth header.
+//
+
+typedef struct _BLUETOOTH_DEVICE_SEARCH_PARAMS BLUETOOTH_DEVICE_SEARCH_PARAMS;
+typedef struct _BLUETOOTH_DEVICE_INFO BLUETOOTH_DEVICE_INFO;
+typedef struct _BLUETOOTH_FIND_RADIO_PARAMS BLUETOOTH_FIND_RADIO_PARAMS;
+
+typedef HANDLE HBLUETOOTH_DEVICE_FIND;
+typedef HANDLE HBLUETOOTH_RADIO_FIND;
 
 //
 // Classic Bluetooth APIs are implemented by Windows in bthprops.cpl.

--- a/01-Extended DLLs/KxUser/kxuser.def
+++ b/01-Extended DLLs/KxUser/kxuser.def
@@ -25,28 +25,28 @@ EXPORTS
 	;;BluetoothEnumerateInstalledServicesEx
 	;;BluetoothFindBrowseGroupClose
 	;;BluetoothFindClassIdClose
-	;;BluetoothFindDeviceClose
+	BluetoothFindDeviceClose
 	;;BluetoothFindFirstBrowseGroup
 	;;BluetoothFindFirstClassId
-	;;BluetoothFindFirstDevice
+	BluetoothFindFirstDevice
 	;;BluetoothFindFirstProfileDescriptor
 	;;BluetoothFindFirstProtocolDescriptorStack
 	;;BluetoothFindFirstProtocolEntry
-	;;BluetoothFindFirstRadio
+	BluetoothFindFirstRadio
 	;;BluetoothFindFirstService
 	;;BluetoothFindFirstServiceEx
 	;;BluetoothFindNextBrowseGroup
 	;;BluetoothFindNextClassId
-	;;BluetoothFindNextDevice
+	BluetoothFindNextDevice
 	;;BluetoothFindNextProfileDescriptor
 	;;BluetoothFindNextProtocolDescriptorStack
 	;;BluetoothFindNextProtocolEntry
-	;;BluetoothFindNextRadio
+	BluetoothFindNextRadio
 	;;BluetoothFindNextService
 	;;BluetoothFindProfileDescriptorClose
 	;;BluetoothFindProtocolDescriptorStackClose
 	;;BluetoothFindProtocolEntryClose
-	;;BluetoothFindRadioClose
+	BluetoothFindRadioClose
 	;;BluetoothFindServiceClose
 	;;BluetoothGetDeviceInfo
 	;;BluetoothGetRadioInfo


### PR DESCRIPTION
## Summary

Fix classic Bluetooth API compatibility in `KxUser`.

This change adds runtime wrappers for six classic Bluetooth APIs that are
provided by the Windows Bluetooth properties module:

- `BluetoothFindFirstDevice`
- `BluetoothFindNextDevice`
- `BluetoothFindDeviceClose`
- `BluetoothFindFirstRadio`
- `BluetoothFindNextRadio`
- `BluetoothFindRadioClose`

The functions are exported by `KxUser` and resolved at runtime from the
system `bthprops.cpl` using `LoadSystemLibrary()` and `GetProcAddress()`.

No `.def` forwarders to `bthprops.cpl` are used.

## Changes

- Added wrappers for the six classic Bluetooth APIs in `blutooth.c`.
- Added the six corresponding exports to `kxuser.def`.
- Avoided including the Windows 7.1 SDK `BluetoothAPIs.h` in `blutooth.c`,
  because its malformed pragma declarations produce warnings which are
  treated as errors by the project's `/WX` build configuration.
- Existing GATT-related code was left unchanged.

## Validation

- Full GitHub Actions build completed successfully using the project's
  Windows 7.1 SDK toolchain.
- Release installer was generated successfully.
- Runtime regression test was performed on Windows 7 with VxKex enabled.
- The test executable imports all six classic `BluetoothFind*` APIs from
  `BluetoothApis.dll`; all six corresponding `KxUser` exports were resolved.
- The `BluetoothFindFirstRadio` probe reached the API and returned
  `NULL` with `LastError = 0x0000051A`.

The original application used to reproduce #435 is no longer available,
so validation was performed with a dedicated regression test executable.

Fixes #435.